### PR TITLE
feat(backend): implement first version

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,13 +1,32 @@
-from flask import Flask
+from flask import Flask, request, jsonify
 from flask_cors import CORS
+from openai import OpenAI
+from utils import generate_exam
 
 app = Flask(__name__)
 cors = CORS(app)
 
 
-@app.route("/")
+@app.route("/api/")
 def hello_world():
     return "Hello, World!"
+
+
+@app.route("/api/generate-exam", methods=["POST"])
+def receive_data():
+    data = request.get_json()
+    context = data.get("context")
+    client = OpenAI(api_key=data.get("api_key"))
+
+    try:
+        questions = generate_exam(client, context)
+
+        return jsonify(
+            {"message": "Exam generated successfully!", "questions": questions}
+        )
+
+    except ValueError as ve:
+        return jsonify({"error": str(ve)}), 500
 
 
 if __name__ == "__main__":

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 flask-cors
 black
+openai

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,0 +1,24 @@
+def generate_exam(client, context):
+    try:
+        response = client.completions.create(
+            model="gpt-3.5-turbo-instruct",
+            prompt=f"""
+            Para criar uma prova de múltipla escolha sobre o seguinte tema:
+            
+            {context}
+            
+            Por favor, inclua perguntas variadas que avaliem diferentes aspectos do tema. Utilize uma linguagem clara e objetiva nas questões e certifique-se de que cada pergunta tenha apenas uma resposta correta.
+
+            Pergunta:
+            """,
+            max_tokens=1024,
+            temperature=0.7,
+            top_p=1.0,
+            stop="\n\nPergunta:",
+        )
+
+        questions = response.choices[0].text
+        return questions
+
+    except Exception as e:
+        raise ValueError(f"Error generating exam: {str(e)}")


### PR DESCRIPTION
#### What I did

- Implemented the first version of our backend. Below is a detailed breakdown of the implemented features:
   - **Endpoints**:
     - Adopted `/api/` as the prefix for all endpoints.
     - Created a new endpoint: `/api/generate-exam`.
   - **Utils**:
     - Developed the `generate_exam()` function to utilize the OpenAI API for exam generation.

This PR does not cover the evaluation part shown in the architecture diagram linked to the issue. However, it includes the minimum features needed for our first version.

Closes #6 